### PR TITLE
Changes to default limit & ability to select only the fields you want returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ Usage:
 ## Limits
 
 By default queries are limited to 20 values. This can be bypassed by passing the `nolimit` option, which if set to true will not limit any queries.
+
+## Fields
+
+To filter the fields returned from the `list` operation, pass a `fields$` array of column names to return. If no `fields$` are passed, all fields are returned (i.e. `select *` is used). e.g.
+
+    query.fields$ = ['id', 'name']

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Usage:
       host:'127.0.0.1',
       port:5432,
       username:'user',
-      password:'password'
+      password:'password',
+      nolimit: true
     };
 
     ...
@@ -33,3 +34,7 @@ Usage:
 [postgresqlorg]: http://www.postgresql.org/
 [seneca]: http://senecajs.org/
 [nodepg]: https://github.com/brianc/node-postgres
+
+## Limits
+
+By default queries are limited to 20 values. This can be bypassed by passing the `nolimit` option, which if set to true will not limit any queries.

--- a/lib/postgresql-store.js
+++ b/lib/postgresql-store.js
@@ -15,11 +15,11 @@ var MIN_WAIT = 16
 var MAX_WAIT = 5000
 
 module.exports = function (opts) {
-
   var seneca = this;
 
   opts.minwait = opts.minwait || MIN_WAIT
   opts.maxwait = opts.maxwait || MAX_WAIT
+  var nolimit = opts.nolimit || false
 
   var minwait
   var dbinst = null
@@ -310,7 +310,7 @@ module.exports = function (opts) {
               query: query
             }
             seneca.log.error('Query Failed', JSON.stringify(errorDetails, null, 1))
-            callback(err, undefined)
+            cb(err)
           }
         })
       }
@@ -595,7 +595,8 @@ module.exports = function (opts) {
     if (q.limit$) {
       mq.params.push('LIMIT ' + q.limit$)
     } else {
-      mq.params.push('LIMIT 20')
+      if (nolimit === false)
+        mq.params.push('LIMIT 20')
     }
 
     if( q.skip$ ) {
@@ -613,7 +614,7 @@ module.exports = function (opts) {
       cb(err)
     })
   })
-  
+
   return { name:store.name, tag:meta.tag };
 
 }

--- a/lib/postgresql-store.js
+++ b/lib/postgresql-store.js
@@ -230,8 +230,8 @@ module.exports = function (opts) {
 
       var query
 
-      if(q.distinct$) {
-        query = distinctStatement(qent, q)
+      if(q.distinct$ || q.fields$) {
+        query = filterStatement(qent, q)
       } else if(q.ids) {
         query = selectstmOr(qent, q)
       } else {
@@ -423,7 +423,7 @@ module.exports = function (opts) {
   }
 
 
-  var distinctStatement = function (qent, q) {
+  var filterStatement = function (qent, q) {
     var stm = {}
 
     var table = relationalstore.tablename(qent)
@@ -454,17 +454,18 @@ module.exports = function (opts) {
 
     var metastr = ' ' + mq.params.join(' ')
 
-    var distinctParams = q.distinct$
+    var filterParams = q.distinct$ || q.fields$
 
     var selectColumns = []
-    if(distinctParams && !_.isString(distinctParams) && _.isArray(distinctParams)) {
-      selectColumns = distinctParams
+    if(filterParams && !_.isString(filterParams) && _.isArray(filterParams)) {
+      selectColumns = filterParams
     }
     if(selectColumns.length === 0) {
       selectColumns.push('*')
     }
 
-    stm.text = "SELECT DISTINCT "+ escapeStr(selectColumns.join(',')) +" FROM " + escapeStr(table) + wherestr + escapeStr(metastr)
+    var select = 'SELECT ' + (q.distinct$ ? 'DISTINCT ' : '');
+    stm.text = select + escapeStr(selectColumns.join(',')) +" FROM " + escapeStr(table) + wherestr + escapeStr(metastr)
     stm.values = values
 
     return stm


### PR DESCRIPTION
- make the 20 records limit optional (new 'nolimit' option)
- added ability to return just the fields you want from a select statement (instead of always 'select *')
- fixed callback -> cb

@nherment @cristianianto @piccoloaiutante please review :-) 
